### PR TITLE
Make RDD.count() fast

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1224,7 +1224,8 @@ abstract class RDD[T: ClassTag](
   /**
    * Return the number of elements in the RDD.
    */
-  def count(): Long = sc.runJob(this, Utils.getIteratorSize _).sum
+//  def count(): Long = sc.runJob(this, Utils.getIteratorSize _).sum
+  def count(): Long = sc.runJob(this, Utils.getPartitionDataSize[T] _).sum
 
   /**
    * Approximate version of count() that returns a potentially incomplete result

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1224,7 +1224,6 @@ abstract class RDD[T: ClassTag](
   /**
    * Return the number of elements in the RDD.
    */
-//  def count(): Long = sc.runJob(this, Utils.getIteratorSize _).sum
   def count(): Long = sc.runJob(this, Utils.getPartitionDataSize[T] _).sum
 
   /**

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1575,6 +1575,16 @@ private[spark] object Utils extends Logging {
     count
   }
 
+  def getPartitionDataSize[T](data: PartitionData[T]): Long = {
+    val count = data match {
+      case IteratorPartitionData(iter) =>
+        getIteratorSize(iter)
+      case col: ColumnPartitionData[T] =>
+        col.size
+    }
+    count
+  }
+
   /**
    * Creates a symlink. Note jdk1.7 has Files.createSymbolicLink but not used here
    * for jdk1.6 support.  Supports windows by doing copy, everything else uses "ln -sf".

--- a/core/src/test/scala/org/apache/spark/cuda/CUDAFunctionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/cuda/CUDAFunctionSuite.scala
@@ -50,6 +50,26 @@ class CUDAFunctionSuite extends SparkFunSuite with LocalSparkContext {
     SparkEnv.get.closureSerializer.newInstance().serialize(function)
   }
 
+  test("Run count()", GPUTest) {
+    sc = new SparkContext("local", "test", conf)
+    val manager = {
+      try {
+        new CUDAManager
+      } catch {
+        case ex: Exception => null
+      }
+    }
+    if (manager != null && manager.deviceCount > 0) {
+      val n = 32
+      val output = sc.parallelize(1 to n, 4)
+        .convert(ColumnFormat)
+        .count()
+      assert(output == n)
+    } else {
+      info("No CUDA devices, so skipping the test.")
+    }
+  }
+
   test("Run identity CUDA kernel on a single primitive column", GPUTest) {
     sc = new SparkContext("local", "test", conf)
     val manager = {


### PR DESCRIPTION
avoid calling ColumnPartitionData.deserialize()
